### PR TITLE
wrktUI-4 wrkoutBackground color set to white

### DIFF
--- a/Sources/wrkoutUI/Backgrounds/WrkoutBackground.swift
+++ b/Sources/wrkoutUI/Backgrounds/WrkoutBackground.swift
@@ -20,7 +20,7 @@ public struct WrkoutBackground: View {
     
     public var body: some View {
         ZStack {
-            Color.wrkoutOcean
+            Color.white
                 .opacity(opacity)
                 .cornerRadius(self.cornerRadius)
                 .overlay(RoundedRectangle(cornerRadius: cornerRadius).stroke(Color.wrkoutDarkGray, lineWidth: 0.5))


### PR DESCRIPTION
### Version: _1.0.4_

### Description:

- Set WrkoutBackgroundView to white instead of wrkoutOcean.